### PR TITLE
Add covariance & additional alt fn's for bias test

### DIFF
--- a/fitting/Fitter.py
+++ b/fitting/Fitter.py
@@ -126,6 +126,9 @@ class Fitter(object):
         self.frame=self.w.var(poi).frame()
 
         f = ROOT.TFile.Open("fitresults.root",'READ')
+
+        linear_errors = False
+
         if f: 
             fr = f.Get('fitresults')
         else:
@@ -135,12 +138,12 @@ class Fitter(object):
         if binning:
             self.w.data(data).plotOn(self.frame,ROOT.RooFit.Binning(binning),ROOT.RooFit.Invisible())
             if fr: 
-                self.w.pdf(model).plotOn(self.frame,ROOT.RooFit.VisualizeError(fr,1),ROOT.RooFit.FillColor(ROOT.kRed-7),ROOT.RooFit.LineColor(ROOT.kRed-7),ROOT.RooFit.Name(fr.GetName()))
+                self.w.pdf(model).plotOn(self.frame,ROOT.RooFit.VisualizeError(fr,1, linear_errors),ROOT.RooFit.FillColor(ROOT.kRed-7),ROOT.RooFit.LineColor(ROOT.kRed-7),ROOT.RooFit.Name(fr.GetName()))
                 self.w.pdf(model).plotOn(self.frame,ROOT.RooFit.LineColor(ROOT.kRed+1))	 
         else: 
             self.w.data(data).plotOn(self.frame,ROOT.RooFit.Invisible())
             if fr: 
-                self.w.pdf(model).plotOn(self.frame,ROOT.RooFit.VisualizeError(fr,1),ROOT.RooFit.FillColor(ROOT.kRed-7),ROOT.RooFit.LineColor(ROOT.kRed-7),ROOT.RooFit.Name(fr.GetName()))
+                self.w.pdf(model).plotOn(self.frame,ROOT.RooFit.VisualizeError(fr,1, linear_errors),ROOT.RooFit.FillColor(ROOT.kRed-7),ROOT.RooFit.LineColor(ROOT.kRed-7),ROOT.RooFit.Name(fr.GetName()))
                 self.w.pdf(model).plotOn(self.frame,ROOT.RooFit.LineColor(ROOT.kRed+1))
 
         if binning: self.w.data(data).plotOn(self.frame,ROOT.RooFit.Binning(binning))

--- a/fitting/Fitter.py
+++ b/fitting/Fitter.py
@@ -285,6 +285,24 @@ class Fitter(object):
             model = ROOT.RooGenericPdf(name, " pow(@0/13000.,-@1) * exp( -@2 * @0/13000. - @3 * pow( @0/13000., 2) - @4 * pow(@0 / 13000., 3))", 
                 ROOT.RooArgList(poi, self.w.var("ap1"), self.w.var("ap2"), self.w.var("ap3"), self.w.var("ap4")))
 
+        elif( ver == 3):
+            self.w.factory("ap1[9.28433e+00, -100. , 100.]")
+            self.w.factory("ap2[1.03641e+01, -200, 200]")	 
+            self.w.factory("ap3[2.35256e+00, -100., 100.]")
+            self.w.factory("ap4[4.17695e-01, -100., 100.]")
+
+            model = ROOT.RooGenericPdf(name, " pow(@0/13000.,-@1) * exp( -@2 * @0/13000. - @3 * pow( @0/13000., 2))", 
+                ROOT.RooArgList(poi, self.w.var("ap1"), self.w.var("ap2"), self.w.var("ap3")))
+
+        elif( ver == 4):
+            self.w.factory("ap1[9.28433e+00, -100. , 100.]")
+            self.w.factory("ap2[1.03641e+01, -200, 200]")	 
+            self.w.factory("ap3[2.35256e+00, -100., 100.]")
+            self.w.factory("ap4[4.17695e-01, -100., 100.]")
+
+            model = ROOT.RooGenericPdf(name, " pow(@0/13000.,-@1) * exp( -@2 * @0/13000. )", 
+                ROOT.RooArgList(poi, self.w.var("ap1"), self.w.var("ap2") ))
+
         getattr(self.w,'import')(model,ROOT.RooFit.Rename(name))
         return model
 

--- a/fitting/Utils.py
+++ b/fitting/Utils.py
@@ -584,9 +584,14 @@ def checkSBFit(filename,label,bins,plotname, nPars, plot_dir = "", draw_sig = Tr
     frame = mjj.frame()
     pdf_name = 'JJ_%s'%label
     
+    #use toys to sample errors rather than linear method, 
+    #needed b/c dijet fn's usually has strong correlation of params
+    linear_errors = False
+
     data.plotOn(frame, ROOT.RooFit.DataError(ROOT.RooAbsData.Poisson), ROOT.RooFit.Binning(roobins),ROOT.RooFit.Name("data_obs"),ROOT.RooFit.Invisible(), 
             ROOT.RooFit.Rescale(rescale))
-    model.getPdf(pdf_name).plotOn(frame,ROOT.RooFit.VisualizeError(fres,1),ROOT.RooFit.FillColor(ROOT.kRed-7),ROOT.RooFit.LineColor(ROOT.kRed-7),ROOT.RooFit.Name(fres.GetName()),
+
+    model.getPdf(pdf_name).plotOn(frame,ROOT.RooFit.VisualizeError(fres,1, linear_errors),ROOT.RooFit.FillColor(ROOT.kRed-7),ROOT.RooFit.LineColor(ROOT.kRed-7),ROOT.RooFit.Name(fres.GetName()),
             fit_norm)
     if(draw_sig):
         model.getPdf(pdf_name).Print("V")

--- a/fitting/Utils.py
+++ b/fitting/Utils.py
@@ -84,6 +84,10 @@ def get_palette(mode):
   palette['gv'].append(c)
  
  return palette[mode]
+
+def convert_matrix(mat):
+    mat_arr = mat.GetMatrixArray()
+    return [[mat_arr[i + j*mat.GetNrows()] for j in range(mat.GetNcols())] for i in range(mat.GetNrows())]
  
 def getBinning(binsMVV,minx,maxx,bins):
     l=[]

--- a/fitting/bias_test.py
+++ b/fitting/bias_test.py
@@ -119,7 +119,7 @@ def bias_test(options):
     data_name = "data_qcd"
 
     #Do fit with alt bkg shape
-    if(options.alt_shape_ver == 2):
+    if(options.alt_shape_ver == 2 or options.alt_shape_ver == 1):
         nPars = 4
     elif(options.alt_shape_ver == 3):
         nPars = 3

--- a/fitting/bias_test.py
+++ b/fitting/bias_test.py
@@ -159,13 +159,16 @@ def bias_test(options):
     rescale = 100./ default_norm
     fit_norm = ROOT.RooFit.Normalization(rescale,ROOT.RooAbsReal.Relative)
 
+    #use toys to sample errors rather than linear method, 
+    #needed b/c dijet fn's usually has strong correlation of params
+    linear_errors = False
 
 
     frame = mjj.frame()
     dataset.plotOn(frame, ROOT.RooFit.Name(data_name), ROOT.RooFit.Invisible(), ROOT.RooFit.Binning(roobins), ROOT.RooFit.DataError(ROOT.RooAbsData.SumW2), 
             ROOT.RooFit.Rescale(rescale))
 
-    model.plotOn(frame, ROOT.RooFit.VisualizeError(fres, 1), ROOT.RooFit.FillColor(ROOT.kRed - 7), ROOT.RooFit.LineColor(ROOT.kRed - 7), ROOT.RooFit.Name(fres.GetName()), 
+    model.plotOn(frame, ROOT.RooFit.VisualizeError(fres, 1, linear_errors), ROOT.RooFit.FillColor(ROOT.kRed - 7), ROOT.RooFit.LineColor(ROOT.kRed - 7), ROOT.RooFit.Name(fres.GetName()), 
                    fit_norm)
 
     model.plotOn(frame, ROOT.RooFit.LineColor(ROOT.kRed + 1), ROOT.RooFit.Name(model_name),  fit_norm)
@@ -310,7 +313,7 @@ def bias_test(options):
     genDataset.plotOn(frame_toy, ROOT.RooFit.Invisible(), ROOT.RooFit.Binning(roobins), ROOT.RooFit.DataError(ROOT.RooAbsData.SumW2), ROOT.RooFit.Name(toy_data_name),
             ROOT.RooFit.Rescale(rescale))
 
-    SB_fit_pdf.plotOn(frame_toy, ROOT.RooFit.VisualizeError(fit_res, 1), ROOT.RooFit.FillColor(ROOT.kRed - 7), ROOT.RooFit.LineColor(ROOT.kRed - 7), ROOT.RooFit.Name(fit_res.GetName()), 
+    SB_fit_pdf.plotOn(frame_toy, ROOT.RooFit.VisualizeError(fit_res, 1, linear_errors), ROOT.RooFit.FillColor(ROOT.kRed - 7), ROOT.RooFit.LineColor(ROOT.kRed - 7), ROOT.RooFit.Name(fit_res.GetName()), 
                    fit_norm)
 
     SB_fit_pdf.plotOn(frame_toy,  ROOT.RooFit.Components(reg_model_name), ROOT.RooFit.LineColor(ROOT.kMagenta + 3),ROOT.RooFit.Name("Background"), fit_norm)

--- a/fitting/bias_test.py
+++ b/fitting/bias_test.py
@@ -119,7 +119,12 @@ def bias_test(options):
     data_name = "data_qcd"
 
     #Do fit with alt bkg shape
-    nPars = 4
+    if(options.alt_shape_ver == 2):
+        nPars = 4
+    elif(options.alt_shape_ver == 3):
+        nPars = 3
+    elif(options.alt_shape_ver == 4):
+        nPars = 2
     qcd_alt_fname = "altBkg_fit.root"
 
 
@@ -127,7 +132,7 @@ def bias_test(options):
 
     model_name = "model_alt"
     fitter_QCD = Fitter(['mjj_fine'], debug = False)
-    if(options.alt_shape_ver != 1 and options.alt_shape_ver != 2):
+    if(options.alt_shape_ver  <= 0 or options.alt_shape_ver >4):
         print("Unsupported alt_shape_ver %i " % options.alt_shape_ver)
         exit(1)
     alt_bkg_pdf = fitter_QCD.altBkgShape(model_name, 'mjj_fine', options.alt_shape_ver)

--- a/fitting/dijetfit.py
+++ b/fitting/dijetfit.py
@@ -271,13 +271,16 @@ def dijetfit(options):
         rescale = 100./ default_norm
         fit_norm = ROOT.RooFit.Normalization(rescale,ROOT.RooAbsReal.Relative)
 
+        #use toys to sample errors rather than linear method, 
+        #needed b/c dijet fn's usually has strong correlation of params
+        linear_errors = False
 
 
         frame = mjj.frame()
         dataset.plotOn(frame, ROOT.RooFit.Name(data_name), ROOT.RooFit.Invisible(), ROOT.RooFit.Binning(roobins), ROOT.RooFit.DataError(ROOT.RooAbsData.SumW2), 
                 ROOT.RooFit.Rescale(rescale))
 
-        model.plotOn(frame, ROOT.RooFit.VisualizeError(fres, 1), ROOT.RooFit.FillColor(ROOT.kRed - 7), ROOT.RooFit.LineColor(ROOT.kRed - 7), ROOT.RooFit.Name(fres.GetName()), 
+        model.plotOn(frame, ROOT.RooFit.VisualizeError(fres, 1, linear_errors), ROOT.RooFit.FillColor(ROOT.kRed - 7), ROOT.RooFit.LineColor(ROOT.kRed - 7), ROOT.RooFit.Name(fres.GetName()), 
                        fit_norm)
 
         model.plotOn(frame, ROOT.RooFit.LineColor(ROOT.kRed + 1), ROOT.RooFit.Name(model_name),  fit_norm)
@@ -324,7 +327,6 @@ def dijetfit(options):
 
         #Get hist of pulls:  (data - fit) / tot_unc
         hresid_norm = get_pull_hist(model, frame, central, curve, hresid, fit_hist,  bins)
-        #hresid_norm.Print("range")
 
 
         err_on_sig = (upBound.Eval(options.mass) - loBound.Eval(options.mass))/2.

--- a/fitting/dijetfit.py
+++ b/fitting/dijetfit.py
@@ -242,9 +242,9 @@ def dijetfit(options):
         fitter_QCD.qcdShape(model_name, 'mjj_fine', nPars)
         fitter_QCD.importBinnedData(fitting_histogram, ['mjj_fine'], data_name)
         
-        #Running fit two times seems to improve things (better initial guesses for params?)
-        fres = fitter_QCD.fit(model_name, data_name, options=[ROOT.RooFit.Save(1), ROOT.RooFit.Verbose(0),  ROOT.RooFit.Minos(1)])
-        fres = fitter_QCD.fit(model_name, data_name, options=[ROOT.RooFit.Save(1), ROOT.RooFit.Verbose(0),  ROOT.RooFit.Minos(1)])
+        fres = fitter_QCD.fit(model_name, data_name, options=[ROOT.RooFit.Save(1), ROOT.RooFit.Verbose(0),  ROOT.RooFit.Minos(1), ROOT.RooFit.Minimizer("Minuit2")])
+        #Running fit two times seems to improve things sometimes (better initial guesses for params?)
+        fres = fitter_QCD.fit(model_name, data_name, options=[ROOT.RooFit.Save(1), ROOT.RooFit.Verbose(0),  ROOT.RooFit.Minos(1), ROOT.RooFit.Minimizer("Minuit2")])
 
         chi2_fine = fitter_QCD.projection(
             model_name, data_name, "mjj_fine",
@@ -329,7 +329,8 @@ def dijetfit(options):
         hresid_norm = get_pull_hist(model, frame, central, curve, hresid, fit_hist,  bins)
 
 
-        err_on_sig = (upBound.Eval(options.mass) - loBound.Eval(options.mass))/2.
+        #abs because somtimes order is reversed
+        err_on_sig = abs(upBound.Eval(options.mass) - loBound.Eval(options.mass))/2.
         frac_err_on_sig = err_on_sig / central.Eval(options.mass)
         bkg_fit_frac_err = frac_err_on_sig
 
@@ -439,9 +440,9 @@ def dijetfit(options):
         + "&& combine -M Significance workspace_JJ_{l1}_{l2}.root "
         + "-m {mass} -n significance_{l1}_{l2} "
         + "&& combine -M Significance workspace_JJ_{l1}_{l2}.root "
-        + "-m {mass} --pvalue -n pvalue_{l1}_{l2}"
+        + "-m {mass} --pvalue -n pvalue_{l1}_{l2} "
         + "&& combine -M AsymptoticLimits workspace_JJ_{l1}_{l2}.root "
-        + "-m {mass} -n lim_{l1}_{l2}"
+        + "-m {mass} -n lim_{l1}_{l2} "
         ).format(mass=mass, l1=label, l2=sb_label)
     print(cmd)
     os.system(cmd)

--- a/fitting/dijetfit.py
+++ b/fitting/dijetfit.py
@@ -216,6 +216,7 @@ def dijetfit(options):
 
     nParsToTry = [2, 3, 4]
     chi2s = [0]*len(nParsToTry)
+    fit_params = [0] * len(nParsToTry)
     ndofs = [0]*len(nParsToTry)
     probs = [0]*len(nParsToTry)
     fit_errs = [0]*len(nParsToTry)
@@ -346,14 +347,21 @@ def dijetfit(options):
 
 
 
+
+
+
         #largest_frac_err = 0.
+        bkg_fit_params = dict()
         for var, graph in graphs.iteritems():
             print(var)
             value, error = fitter_QCD.fetch(var)
+            bkg_fit_params[var] = (value, error)
             graph.SetPoint(0, mass, value)
             graph.SetPointError(0, 0.0, error)
             #frac_err = abs(error/value)
             #largest_frac_err = max(frac_err, largest_frac_err)
+        bkg_fit_params['cov'] = convert_matrix(fres.covarianceMatrix())
+        print(bkg_fit_params['cov'])
 
         qcd_outfile.cd()
         for name, graph in graphs.iteritems():
@@ -371,6 +379,7 @@ def dijetfit(options):
         chi2s[i] = my_chi2
         ndofs[i] = my_ndof
         probs[i] = my_prob
+        fit_params[i] = bkg_fit_params
         fit_errs[i] = bkg_fit_frac_err
         fitter_QCD.delete()
 
@@ -497,6 +506,7 @@ def dijetfit(options):
     results['bkgfit_ndof'] = ndofs[best_i]
     results['bkgfit_prob'] = probs[best_i]
     results['bkgfit_frac_err'] = fit_errs[best_i]
+    results['bkg_fit_params'] = fit_params[best_i]
     results['sbfit_chi2'] = sbfit_chi2
     results['sbfit_ndof'] = sbfit_ndof
     results['sbfit_prob'] = sbfit_prob


### PR DESCRIPTION
Save additional info from the the bkg only fit (needed for weak supervision plotting). Use better method to get fit uncertainties, which prevents a lot of the super large errors that can appear in the postfit plots. Add additional alt fn's with fewer parameters for bias study